### PR TITLE
Add airlfow to aio network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - .env
     ports:
       - "127.0.0.1:${AIRFLOW_POSTGRES_PORT}:5432"
+    networks:
+      - aio-elasticsearch-network
     container_name: "airflow-db-${AIRFLOW_ENV_TYPE}-${AIRFLOW_ENV_NAME}"
   webserver:
     build:
@@ -30,6 +32,8 @@ services:
     ports:
       - "127.0.0.1:${AIRFLOW_WEBSERVER_PORT}:8080"
       - "127.0.0.1:${AIRFLOW_LOG_SERVER_PORT}:8793"
+    networks:
+      - aio-elasticsearch-network
     entrypoint: ./scripts/airflow-entrypoint.sh
     healthcheck:
       test: ["CMD-SHELL", "[ -f /opt/airflow/airflow-webserver.pid ]"]
@@ -37,3 +41,6 @@ services:
       timeout: 30s
       retries: 32
     container_name: "airflow-${AIRFLOW_ENV_TYPE}-${AIRFLOW_ENV_NAME}"
+networks:
+  aio-elasticsearch-network:
+    name: aio-elasticsearch-network

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ requests==2.27.1
 python-dotenv==0.20.0
 swifter==1.1.3
 tweepy==4.8.0
+redis


### PR DESCRIPTION
Adding `airflow` to `aio` network makes it possible to communicate with redis container without having to expose redis container.