### PR TITLE
[PYTHON]ops: update airflow setup & Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.1-python3.8
+FROM apache/airflow:2.7.3-python3.10
 
 USER root 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,9 @@ PyYAML
 geojson
 shapely
 minio==7.1.3
-boto3==1.17.112
+boto3==1.28.0
 emails==0.6
-pandas==1.1.5
-cchardet==2.1.7
+pandas==1.5.3
 papermill==2.3.4
 plotly==5.6.0
 plotly_express==0.4.1
@@ -21,8 +20,9 @@ openpyxl==3.0.9
 elasticsearch==7.17.0
 elasticsearch_dsl==7.4.0
 requests==2.31.0
-python-dotenv==0.20.0
+python-dotenv==0.21.0
 swifter==1.1.3
 tweepy==4.8.0
 pytest==7.2.1
 langdetect==1.0.9
+pydantic==2.3.0


### PR DESCRIPTION
Python 3.8 and dependencies created conflicts when trying to install Pydantic V2.